### PR TITLE
Only upload the most recent files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,11 @@ readonly SOURCE_MAPS_DIRECTORY=$(cat ${SOURCE_MAPS_PATH_CONFIG_FILE})
 echo "-----> Uploading source maps..."
 
 for source_map_full_path in $(ls $SOURCE_MAPS_DIRECTORY/*.js*.map); do
+  source_map_file_pattern="${source_map_full_path%-*.map}-*.map"
+  newest_map_file=$(ls -t ${source_map_file_pattern} | head -n 1)
+
+  [[ $source_map_full_path != $newest_map_file ]] && continue
+
   # For example, next line returns something like application.js-953b9963fa86c1e67de0cba30d95743859144257.map
   source_map_file_name=$(basename ${source_map_full_path})
   # For example, next line returns something like application.js


### PR DESCRIPTION
The server might have assets compiled on past deployments, which we don't want to upload.

So we are now checking if the source map on the iteration is the newest one. If not we skip the rest of the loop to not upload it.

Before:

![image](https://user-images.githubusercontent.com/73012/205123406-6a065842-802d-461d-afe0-1b8d4d9eeb17.png)

After:

![image](https://user-images.githubusercontent.com/73012/205123199-b8fbf34c-ad4f-4bd3-b350-691e5944f0c0.png)
